### PR TITLE
ci(lint): enable errorlint linter on cmd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
+          cache: false
           go-version: 1.20.x
       - name: Install snmp_exporter/generator dependencies
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ output:
 linters:
   enable:
     - depguard
+    - errorlint
     - gocritic
     - gofumpt
     - goimports
@@ -31,6 +32,27 @@ issues:
     - path: _test.go
       linters:
         - errcheck
+    - path: discovery/
+      linters:
+        - errorlint
+    - path: model/
+      linters:
+        - errorlint
+    - path: scrape/
+      linters:
+        - errorlint
+    - path: storage/
+      linters:
+        - errorlint
+    - path: tsdb/
+      linters:
+        - errorlint
+    - path: util/
+      linters:
+        - errorlint
+    - path: web/
+      linters:
+        - errorlint
 
 linters-settings:
   depguard:

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -498,10 +498,9 @@ func TestDocumentation(t *testing.T) {
 	cmd.Stdout = &stdout
 
 	if err := cmd.Run(); err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			if exitError.ExitCode() != 0 {
-				fmt.Println("Command failed with non-zero exit code")
-			}
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) && exitError.ExitCode() != 0 {
+			fmt.Println("Command failed with non-zero exit code")
 		}
 	}
 

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -450,10 +450,9 @@ func TestDocumentation(t *testing.T) {
 	cmd.Stdout = &stdout
 
 	if err := cmd.Run(); err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			if exitError.ExitCode() != 0 {
-				fmt.Println("Command failed with non-zero exit code")
-			}
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) && exitError.ExitCode() != 0 {
+			fmt.Println("Command failed with non-zero exit code")
 		}
 	}
 

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -241,7 +241,7 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 				g.Eval(suite.Context(), ts)
 				for _, r := range g.Rules() {
 					if r.LastError() != nil {
-						evalErrs = append(evalErrs, fmt.Errorf("    rule: %s, time: %s, err: %v",
+						evalErrs = append(evalErrs, fmt.Errorf("    rule: %s, time: %s, err: %w",
 							r.Name(), ts.Sub(time.Unix(0, 0).UTC()), r.LastError()))
 					}
 				}


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
